### PR TITLE
Made LLVM an optional (but default) dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,14 @@ path = "src/main.rs"
 test = false
 doc = false
 
+[features]
+default = ["llvm-backend"]
+llvm-backend = ["llvm-sys"]
+
 [dependencies]
 docopt = "*"
 env_logger = "*"
-llvm-sys = "*"
+llvm-sys = {version="0.2.1", optional=true}
 log = "*"
 rustc-serialize = "*"
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Limonite is a relatively basic programming language written in rust using LLVM a
 
 ## Building
 1. Make sure you have installed all the dependencies.
-	* Rust (Stable/Beta)
-	* Cargo
-	* git
-	* LLVM >= 3.6
-	* cmake
+    * Rust (>= 1.16.0)
+    * Cargo
+    * git (optional)
+    * LLVM >= 3.6 (optional)
+    * cmake (required for LLVM)
 
 2. Download and build Limonite.
 
@@ -27,6 +27,12 @@ Limonite is a relatively basic programming language written in rust using LLVM a
         git clone https://github.com/TheDan64/limonite.git
         cd limonite
         cargo build
+
+    Without LLVM dependency
+
+        git clone https://github.com/TheDan64/limonite.git
+        cd limonite
+        cargo build --no-default-features
 
 ## Working Features
 * Basic variables w/ basic type inference: `var s = "Hello, world!"`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Limonite is a relatively basic programming language written in rust using LLVM a
 
 ## Building
 1. Make sure you have installed all the dependencies.
-    * Rust (>= 1.16.0)
+    * Rust (Stable/Beta)
     * Cargo
     * git (optional)
     * LLVM >= 3.6 (optional)

--- a/src/codegen/llvm/builtins.rs
+++ b/src/codegen/llvm/builtins.rs
@@ -4,7 +4,7 @@ use std::ptr;
 use self::llvm_sys::prelude::*;
 use self::llvm_sys::core::*;
 use self::llvm_sys::*;
-use codegen::codegen::{Context, c_str_ptr};
+use codegen::llvm::codegen::{Context, c_str_ptr};
 
 // Generate LLVM IR for functions built into the language
 pub unsafe fn generate_builtins(context: &mut Context) -> LLVMValueRef {

--- a/src/codegen/llvm/codegen.rs
+++ b/src/codegen/llvm/codegen.rs
@@ -14,7 +14,7 @@ use lexical::types::*;
 use syntax::op::*;
 use syntax::expr::*;
 use syntax::literals::*;
-use codegen::builtins::generate_builtins;
+use codegen::llvm::builtins::generate_builtins;
 
 // Struct to keep track of data needed to build IR
 pub struct Context {

--- a/src/codegen/llvm/mod.rs
+++ b/src/codegen/llvm/mod.rs
@@ -1,0 +1,2 @@
+pub mod codegen;
+pub mod builtins;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,2 +1,2 @@
-pub mod codegen;
-pub mod builtins;
+#[cfg(feature="llvm-backend")]
+pub mod llvm;

--- a/src/lexical/lexer.rs
+++ b/src/lexical/lexer.rs
@@ -483,7 +483,7 @@ impl<'a> Iterator for Lexer<'a> {
     type Item = Tokens;
 
     // Parse the file where it left off and return the next token
-    fn next(&mut self) -> Option<Tokens> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.consume_whitespace();
 
         let tok = match self.next_char() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,8 @@ use lexical::lexer::Lexer;
 use syntax::parser::Parser;
 use semantic::analyzer::SemanticAnalyzer;
 use semantic::analyzer_trait::ASTAnalyzer;
-use codegen::codegen::codegen; // REVIEW: better codegen name convention + class?
+#[cfg(feature="llvm-backend")]
+use codegen::llvm::codegen::codegen; // REVIEW: better codegen name convention + class?
 
 pub mod lexical;
 pub mod syntax;
@@ -86,6 +87,7 @@ fn main() {
     semantic_analyzer.analyze(&mut ast_root);
 
     // Run Code Gen
+    #[cfg(feature="llvm-backend")]
     unsafe {
         codegen("module1", &ast_root, args.flag_dump);
     }


### PR DESCRIPTION
You can now do `cargo build/check/run --no-default-features` which will compile without LLVM, however LLVM remains the default and must be opt-ed out of.

Resolves #43 