### PR TITLE
Support for more builtin types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ target
 *.sublime-project
 src/*.o
 testinput*
-Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,271 @@
+[root]
+name = "limonite"
+version = "0.0.5"
+dependencies = [
+ "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "llvm-sys 37.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "docopt"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gcc"
+version = "0.3.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "llvm-sys"
+version = "37.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "log"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "semver"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strsim"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread-id"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab32ea6e284d87987066f21a9e809a73c14720571ef34516f0890b3d355ccfd8"
+"checksum env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e3856f1697098606fc6cb97a93de88ca3f3bc35bb878c725920e6e82ecf05e83"
+"checksum gcc 0.3.45 (registry+https://github.com/rust-lang/crates.io-index)" = "40899336fb50db0c78710f53e87afc54d8c7266fb76262fecc78ca1a7f09deae"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum lazy_static 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7291b1dd97d331f752620b02dfdbc231df7fc01bf282a00769e1cdb963c460dc"
+"checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
+"checksum llvm-sys 37.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a99e94b03d620fee64729a1726e03e9b82a3f4ab28213a25492c4aaed69b4d86"
+"checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
+"checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
+"checksum rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "684ce48436d6465300c9ea783b6b14c4361d6b8dcbb1375b486a69cc19e2dfb0"
+"checksum semver 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ca1c06afc03e8a202bc5c1db01524cceb7e1b1ca062d959d83a61b20d76e394e"
+"checksum semver-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fff3c9c5a54636ab95acd8c1349926e04cb1eb8cd70b5adced8a1d1f703a67"
+"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
+"checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
+"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/README.md
+++ b/README.md
@@ -35,5 +35,22 @@ Limonite is a relatively basic programming language written in rust using LLVM a
         cargo build --no-default-features
 
 ## Working Features
-* Basic variables w/ basic type inference: `var s = "Hello, world!"`
-* Basic ascii/utf8 print statements: `print(s)`
+* Basic variables w/ basic type inference
+* Basic ascii/utf8 print statements
+* While loops
+* Comparison operators
+* Addition, Subtraction, Assignment
+* Comments
+
+Example:
+
+```
+var s = "Spam the world!"
+var i = 10
+
+>> NOTE: The following requires tab-indentation
+
+while i > 0,
+    i -= 1
+    print(s)
+```

--- a/src/codegen/llvm/core.rs
+++ b/src/codegen/llvm/core.rs
@@ -1,7 +1,7 @@
 extern crate llvm_sys;
 
 use self::llvm_sys::analysis::{LLVMVerifyModule, LLVMVerifierFailureAction, LLVMVerifyFunction};
-use self::llvm_sys::core::{LLVMContextCreate, LLVMCreateBuilderInContext, LLVMModuleCreateWithNameInContext, LLVMContextDispose, LLVMDisposeBuilder, LLVMVoidTypeInContext, LLVMDumpModule, LLVMInt1TypeInContext, LLVMInt8TypeInContext, LLVMInt16TypeInContext, LLVMInt32Type, LLVMInt32TypeInContext, LLVMInt64TypeInContext, LLVMBuildRet, LLVMBuildRetVoid, LLVMPositionBuilderAtEnd, LLVMBuildCall, LLVMBuildStore, LLVMPointerType, LLVMStructTypeInContext, LLVMAddFunction, LLVMFunctionType, LLVMSetValueName, LLVMGetValueName, LLVMCreatePassManager, LLVMBuildExtractValue, LLVMAppendBasicBlockInContext, LLVMBuildLoad, LLVMBuildGEP, LLVMBuildCondBr, LLVMBuildICmp, LLVMBuildCast, LLVMGetNamedFunction, LLVMBuildAdd, LLVMBuildSub, LLVMBuildMul, LLVMConstInt, LLVMGetFirstParam, LLVMGetNextParam, LLVMCountParams, LLVMDisposePassManager, LLVMCreateFunctionPassManagerForModule, LLVMInitializeFunctionPassManager, LLVMDisposeMessage, LLVMArrayType, LLVMGetReturnType, LLVMTypeOf, LLVMGetElementType, LLVMBuildNeg, LLVMBuildNot, LLVMGetNextBasicBlock, LLVMGetFirstBasicBlock, LLVMGetLastBasicBlock, LLVMGetInsertBlock, LLVMGetBasicBlockParent, LLVMConstReal, LLVMConstArray, LLVMBuildBr, LLVMBuildPhi, LLVMAddIncoming, LLVMBuildAlloca, LLVMBuildMalloc, LLVMBuildArrayMalloc, LLVMBuildArrayAlloca, LLVMGetUndef, LLVMSetDataLayout, LLVMGetBasicBlockTerminator, LLVMInsertIntoBuilder, LLVMIsABasicBlock, LLVMIsAFunction, LLVMIsFunctionVarArg, LLVMDumpType, LLVMPrintValueToString, LLVMPrintTypeToString, LLVMInsertBasicBlock, LLVMInsertBasicBlockInContext, LLVMGetParam, LLVMGetTypeKind, LLVMIsConstant, LLVMVoidType, LLVMSetLinkage, LLVMBuildInsertValue, LLVMIsNull, LLVMBuildIsNull, LLVMIsAConstantArray, LLVMIsAConstantDataArray, LLVMBuildPointerCast, LLVMSetGlobalConstant, LLVMSetInitializer, LLVMAddGlobal, LLVMFloatTypeInContext, LLVMDoubleTypeInContext, LLVMStructGetTypeAtIndex, LLVMMoveBasicBlockAfter, LLVMMoveBasicBlockBefore, LLVMGetTypeByName, LLVMBuildFree, LLVMGetParamTypes, LLVMGetBasicBlocks, LLVMIsUndef, LLVMBuildAnd, LLVMBuildOr, LLVMBuildSDiv, LLVMBuildUDiv, LLVMBuildFAdd, LLVMBuildFDiv, LLVMBuildFMul, LLVMBuildXor, LLVMBuildFCmp, LLVMBuildFNeg, LLVMBuildFSub, LLVMBuildUnreachable, LLVMBuildFence, LLVMGetPointerAddressSpace, LLVMIsAConstantPointerNull, LLVMCountParamTypes, LLVMFP128TypeInContext, LLVMIntTypeInContext};
+use self::llvm_sys::core::{LLVMContextCreate, LLVMCreateBuilderInContext, LLVMModuleCreateWithNameInContext, LLVMContextDispose, LLVMDisposeBuilder, LLVMVoidTypeInContext, LLVMDumpModule, LLVMInt1TypeInContext, LLVMInt8TypeInContext, LLVMInt16TypeInContext, LLVMInt32Type, LLVMInt32TypeInContext, LLVMInt64TypeInContext, LLVMBuildRet, LLVMBuildRetVoid, LLVMPositionBuilderAtEnd, LLVMBuildCall, LLVMBuildStore, LLVMPointerType, LLVMStructTypeInContext, LLVMAddFunction, LLVMFunctionType, LLVMSetValueName, LLVMGetValueName, LLVMCreatePassManager, LLVMBuildExtractValue, LLVMAppendBasicBlockInContext, LLVMBuildLoad, LLVMBuildGEP, LLVMBuildCondBr, LLVMBuildICmp, LLVMBuildCast, LLVMGetNamedFunction, LLVMBuildAdd, LLVMBuildSub, LLVMBuildMul, LLVMConstInt, LLVMGetFirstParam, LLVMGetNextParam, LLVMCountParams, LLVMDisposePassManager, LLVMCreateFunctionPassManagerForModule, LLVMInitializeFunctionPassManager, LLVMDisposeMessage, LLVMArrayType, LLVMGetReturnType, LLVMTypeOf, LLVMGetElementType, LLVMBuildNeg, LLVMBuildNot, LLVMGetNextBasicBlock, LLVMGetFirstBasicBlock, LLVMGetLastBasicBlock, LLVMGetInsertBlock, LLVMGetBasicBlockParent, LLVMConstReal, LLVMConstArray, LLVMBuildBr, LLVMBuildPhi, LLVMAddIncoming, LLVMBuildAlloca, LLVMBuildMalloc, LLVMBuildArrayMalloc, LLVMBuildArrayAlloca, LLVMGetUndef, LLVMSetDataLayout, LLVMGetBasicBlockTerminator, LLVMInsertIntoBuilder, LLVMIsABasicBlock, LLVMIsAFunction, LLVMIsFunctionVarArg, LLVMDumpType, LLVMPrintValueToString, LLVMPrintTypeToString, LLVMInsertBasicBlock, LLVMInsertBasicBlockInContext, LLVMGetParam, LLVMGetTypeKind, LLVMIsConstant, LLVMVoidType, LLVMSetLinkage, LLVMBuildInsertValue, LLVMIsNull, LLVMBuildIsNull, LLVMIsAConstantArray, LLVMIsAConstantDataArray, LLVMBuildPointerCast, LLVMSetGlobalConstant, LLVMSetInitializer, LLVMAddGlobal, LLVMFloatTypeInContext, LLVMDoubleTypeInContext, LLVMStructGetTypeAtIndex, LLVMMoveBasicBlockAfter, LLVMMoveBasicBlockBefore, LLVMGetTypeByName, LLVMBuildFree, LLVMGetParamTypes, LLVMGetBasicBlocks, LLVMIsUndef, LLVMBuildAnd, LLVMBuildOr, LLVMBuildSDiv, LLVMBuildUDiv, LLVMBuildFAdd, LLVMBuildFDiv, LLVMBuildFMul, LLVMBuildXor, LLVMBuildFCmp, LLVMBuildFNeg, LLVMBuildFSub, LLVMBuildUnreachable, LLVMBuildFence, LLVMGetPointerAddressSpace, LLVMIsAConstantPointerNull, LLVMCountParamTypes, LLVMFP128TypeInContext, LLVMIntTypeInContext, LLVMBuildIsNotNull, LLVMConstNamedStruct, LLVMStructCreateNamed, LLVMAlignOf, LLVMTypeIsSized, LLVMGetTypeContext, LLVMStructSetBody};
 use self::llvm_sys::execution_engine::{LLVMGetExecutionEngineTargetData, LLVMCreateExecutionEngineForModule, LLVMExecutionEngineRef, LLVMRunFunction, LLVMRunFunctionAsMain, LLVMDisposeExecutionEngine, LLVMLinkInInterpreter, LLVMGetFunctionAddress, LLVMLinkInMCJIT, LLVMAddModule};
 use self::llvm_sys::LLVMLinkage::LLVMCommonLinkage;
 use self::llvm_sys::prelude::{LLVMBuilderRef, LLVMContextRef, LLVMModuleRef, LLVMTypeRef, LLVMValueRef, LLVMBasicBlockRef, LLVMPassManagerRef};
@@ -23,12 +23,16 @@ pub struct Context {
 }
 
 impl Context {
-    pub fn new() -> Self {
+    pub fn create() -> Self {
         let context = unsafe {
             LLVMContextCreate()
         };
 
-        assert!(!context.is_null()); // TODO: All of these on debug only
+        Context::new(context)
+    }
+
+    fn new(context: LLVMContextRef) -> Self {
+        assert!(!context.is_null());
 
         Context {
             context: context
@@ -40,11 +44,7 @@ impl Context {
             LLVMCreateBuilderInContext(self.context)
         };
 
-        assert!(!builder.is_null());
-
-        Builder {
-            builder: builder
-        }
+        Builder::new(builder)
     }
 
     pub fn create_module(&self, name: &str) -> Module {
@@ -54,11 +54,7 @@ impl Context {
             LLVMModuleCreateWithNameInContext(c_string.as_ptr(), self.context)
         };
 
-        assert!(!module.is_null());
-
-        Module {
-            module: module
-        }
+        Module::new(module)
     }
 
     pub fn void_type(&self) -> Type {
@@ -152,15 +148,27 @@ impl Context {
         Type::new(f128_type)
     }
 
-    pub fn struct_type(&self, field_types: Vec<Type>) -> Type { // REVIEW: StructType?
+    pub fn struct_type(&self, field_types: Vec<Type>, packed: bool, name: &str) -> Type { // REVIEW: StructType?
         // WARNING: transmute will no longer work correctly if Type gains more fields
         // We're avoiding reallocation by telling rust Vec<Type> is identical to Vec<LLVMTypeRef>
         let mut field_types: Vec<LLVMTypeRef> = unsafe {
             transmute(field_types)
         };
 
-        let struct_type = unsafe {
-            LLVMStructTypeInContext(self.context, field_types.as_mut_ptr(), field_types.len() as u32, 0) // REVIEW: 0 is what? Safe to cast usize as u32?
+        let struct_type = if name.len() == 0 {
+            unsafe {
+                LLVMStructTypeInContext(self.context, field_types.as_mut_ptr(), field_types.len() as u32, packed as i32)
+            }
+        } else {
+            let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+
+            unsafe {
+                let struct_type = LLVMStructCreateNamed(self.context, c_string.as_ptr());
+
+                LLVMStructSetBody(struct_type, field_types.as_mut_ptr(), field_types.len() as u32, packed as i32);
+
+                struct_type
+            }
         };
 
         Type::new(struct_type)
@@ -211,6 +219,14 @@ pub struct Builder {
 }
 
 impl Builder {
+    fn new(builder: LLVMBuilderRef) -> Self {
+        assert!(!builder.is_null());
+
+        Builder {
+            builder: builder
+        }
+    }
+
     pub fn build_return(&self, value: Option<Value>) -> Value {
         // let value = unsafe {
         //     value.map_or(LLVMBuildRetVoid(self.builder), |value| LLVMBuildRet(self.builder, value.value))
@@ -626,6 +642,26 @@ impl Builder {
 
         Value::new(val)
     }
+
+    pub fn build_is_null(&self, value: &Value, name: &str) -> Value {
+        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+
+        let val = unsafe {
+            LLVMBuildIsNull(self.builder, value.value, c_string.as_ptr())
+        };
+
+        Value::new(val)
+    }
+
+    pub fn build_is_not_null(&self, value: &Value, name: &str) -> Value {
+        let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
+
+        let val = unsafe {
+            LLVMBuildIsNotNull(self.builder, value.value, c_string.as_ptr())
+        };
+
+        Value::new(val)
+    }
 }
 
 impl Drop for Builder {
@@ -641,6 +677,14 @@ pub struct Module {
 }
 
 impl Module {
+    fn new(module: LLVMModuleRef) -> Self {
+        assert!(!module.is_null());
+
+        Module {
+            module: module
+        }
+    }
+
     pub fn add_function(&self, name: &str, return_type: FunctionType) -> FunctionValue {
         let c_string = CString::new(name).expect("Conversion to CString failed unexpectedly");
 
@@ -1066,7 +1110,7 @@ impl Type {
     }
 
     /// REVIEW: Untested
-    pub fn get_undef(&self, type_: &Type) -> Value {
+    pub fn get_undef(&self) -> Value {
         let value = unsafe {
             LLVMGetUndef(self.type_)
         };
@@ -1092,6 +1136,41 @@ impl Type {
     pub fn get_kind(&self) -> LLVMTypeKind {
         unsafe {
             LLVMGetTypeKind(self.type_)
+        }
+    }
+
+    pub fn get_alignment(&self) -> Value {
+        let val = unsafe {
+            LLVMAlignOf(self.type_)
+        };
+
+        Value::new(val)
+    }
+
+    /// REVIEW: Untested
+    pub fn const_struct(&self, value: &mut Value, num: u32) -> Value {
+        // REVIEW: What if not a struct? Need StructType?
+        // TODO: Better name for num. What's it for?
+        let val = unsafe {
+            LLVMConstNamedStruct(self.type_, &mut value.value, num)
+        };
+
+        Value::new(val)
+    }
+
+    /// REVIEW: May or may not make this public...
+    fn get_context(&self) -> Context { // REVIEW: Option<Context>? I believe types can be context-less
+        let context = unsafe {
+            LLVMGetTypeContext(self.type_)
+        };
+
+        Context::new(context)
+    }
+
+    /// REVIEW: Untested
+    pub fn is_sized(&self) -> bool {
+        unsafe {
+            LLVMTypeIsSized(self.type_) == 1
         }
     }
 }

--- a/src/codegen/llvm/std/mod.rs
+++ b/src/codegen/llvm/std/mod.rs
@@ -1,1 +1,2 @@
 pub mod string;
+pub mod vec;

--- a/src/codegen/llvm/std/string.rs
+++ b/src/codegen/llvm/std/string.rs
@@ -1,28 +1,23 @@
 extern crate llvm_sys;
 
-use codegen::llvm::core::{Builder, Context, Module, Type};
+use codegen::llvm::core::{Builder, Context, Module};
 use self::llvm_sys::LLVMIntPredicate; // TODO: Remove
+use codegen::llvm::std::vec::vec_type;
 
-// TODO: Change to put string def in module if not already there
-// use std.string.String
-pub fn string_type(context: &Context) -> Type {
-    let field_types = vec![
-        context.i8_type().ptr_type(0),
-        context.i64_type(), // len
-        context.i64_type(), // cap
-    ];
+pub fn define_string_type(context: &Context) {
+    let i8_ptr_type = context.i8_type().ptr_type(0);
 
-    context.struct_type(field_types)
+    vec_type(&context, i8_ptr_type, "std.string.String")
 }
 
 // TODO: Move out of the string file:
-pub fn print_function_definition(builder: &Builder, context: &Context, module: &Module) {
+pub fn define_print_function(builder: &Builder, context: &Context, module: &Module) {
     // Types
     let void = context.void_type();
     let i32_type = context.i32_type();
     let i64_type = context.i64_type();
     let i32_ptr_type = i32_type.ptr_type(0);
-    let string_type_ptr = string_type(context).ptr_type(0);
+    let string_type_ptr = module.get_type("std.string.String").expect("LLVMGenError: Could not find String definition").ptr_type(0);
 
     let mut args = vec![string_type_ptr];
 

--- a/src/codegen/llvm/std/vec.rs
+++ b/src/codegen/llvm/std/vec.rs
@@ -1,0 +1,11 @@
+use codegen::llvm::core::{Context, Type};
+
+pub fn vec_type(context: &Context, t: Type, type_name: &str) {
+    let field_types = vec![
+        t,
+        context.i64_type(), // len
+        context.i64_type(), // cap
+    ];
+
+    context.struct_type(field_types, false, type_name);
+}

--- a/src/lexical/lexer.rs
+++ b/src/lexical/lexer.rs
@@ -108,54 +108,10 @@ impl<'a> Lexer<'a> {
         Identifier(ident)
     }
 
-    // Find a sequence of 32 or 64
-    fn consume_32_64(&mut self, prefix: char) -> Result<String, String> {
-        // prefix is the starting character, ie i, u, f
-        let mut string = String::new();
-        string.push(prefix);
-
-        match self.next_char() {
-            Some('3') => {
-                string.push(self.consume_char().unwrap());
-
-                match self.next_char() {
-                    Some('2')  => {
-                        string.push(self.consume_char().unwrap());
-
-                        Ok(string)
-                    },
-                    Some('\n') | // NL & CR have pesky visual effects.
-                    Some('\r') => Err(format!("Invalid suffix {}. Did you mean {}32?", string, prefix)),
-                    Some(_)    => Err(format!("Invalid suffix {}{}. Did you mean {0}2?", string, self.consume_char().unwrap())),
-                    None       => Err(format!("Hit EOF when looking for suffix {}32.", prefix))
-                }
-            },
-            Some('6') => {
-                string.push(self.consume_char().unwrap());
-
-                match self.next_char() {
-                    Some('4')  => {
-                        string.push(self.consume_char().unwrap());
-
-                        Ok(string)
-                    },
-                    Some('\n') | // NL & CR have pesky visual effects.
-                    Some('\r') => Err(format!("Invalid suffix {}. Did you mean {}64?", string, prefix)),
-                    Some(_)    => Err(format!("Invalid suffix {}{}. Did you mean {0}4?", string, self.consume_char().unwrap())),
-                    None       => Err(format!("Hit EOF when looking for suffix {}64.", prefix))
-                }
-            },
-            Some('\n') | // NL & CR have pesky visual effects.
-            Some('\r') => Err(format!("Invalid suffix {}. Did you mean {1}32 or {1}64?", string, prefix)),
-            Some(_)    => Err(format!("Invalid suffix {}{}. Did you mean {0}32 or {0}64?", string, self.consume_char().unwrap())),
-            None       => Err(format!("Hit EOF when looking for a suffix {0}32 or {0}64.", prefix))
-        }
-    }
-
     // Determines what type of number it is and consume it
-    fn consume_numeric(&mut self) -> Tokens {
+    fn consume_numeric(&mut self) -> Tokens { // TODO: Change Error token to Result
         let mut number = String::new();
-        let mut suffix = String::new();
+        let mut suffix = None;
 
         match self.next_char() {
             Some('0') => {
@@ -181,28 +137,10 @@ impl<'a> Lexer<'a> {
                             return Error("No hexadecimal value was found.".to_string());
                         }
 
-                        // Attempt to find a suffix if one exists
-                        match self.next_char() {
-                            Some('u') |
-                            Some('i') => {
-                                let ch = self.consume_char().unwrap();
-
-                                match self.consume_32_64(ch) {
-                                    Ok(s)    => suffix.push_str(&s),
-                                    Err(err) => return Error(err)
-                                };
-                            },
-
-                            // Found some other suffix, ie 0x42o
-                            Some(c) if c.is_alphanumeric() => {
-                                let ch = self.consume_char().unwrap();
-                                let err = format!("Invalid suffix {}. Did you mean u32, u64, i32, or i64?", ch);
-
-                                return Error(err);
-                            },
-
-                            // If eof or other just return the numeric token without a suffix
-                            _ => ()
+                        match self.consume_numeric_suffix() {
+                            Ok(Some(t)) => suffix = Some(t),
+                            Ok(None) => (),
+                            Err(e) => return Error(e)
                         };
                     },
                     Some('b') => {
@@ -223,28 +161,52 @@ impl<'a> Lexer<'a> {
                             return Error("No binary value was found.".to_string());
                         }
 
-                        // Attempt to find a suffix if one exists
-                        match self.next_char() {
-                            Some('u') |
-                            Some('i') => {
-                                let ch = self.consume_char().unwrap();
+                        match self.consume_numeric_suffix() {
+                            Ok(Some(t)) => suffix = Some(t),
+                            Ok(None) => (),
+                            Err(e) => return Error(e)
+                        };
+                    },
+                    _ => {
+                        // REVIEW: Better way to do this than two allocations?
+                        // Maybe a consume_while_append which adds to an existing string
+                        // instead of returning one? Happens elsewhere too
+                        number.push('0');
+                        number.push_str(&self.consume_while(&mut |ch| match ch {
+                            '0'...'9' |
+                            '_' => true,
+                             _  => false
+                        }));
 
-                                match self.consume_32_64(ch) {
-                                    Ok(s)    => suffix.push_str(&s),
-                                    Err(err) => return Error(err)
+                        // Can be either float or int
+                        match self.next_char() {
+                            // Float decimal point:
+                            Some('.') => {
+                                number.push(self.consume_char().unwrap());
+
+                                let fractional = self.consume_while(&mut |ch| match ch {
+                                    '0'...'9' |
+                                    '_' => true,
+                                     _  => false
+                                });
+
+                                // Check if no decimal values were found
+                                match &fractional[..] {
+                                    "" => return Error("No numbers found after the decimal point.".to_string()),
+                                    _  => number.push_str(&fractional)
+                                }
+
+                                match self.consume_numeric_suffix() {
+                                    Ok(Some(t)) => suffix = Some(t),
+                                    Ok(None) => (),
+                                    Err(e) => return Error(e)
                                 };
                             },
-
-                            // Found some other suffix, ie 0x42o
-                            Some(c) if c.is_alphabetic() => {
-                                let ch = self.consume_char().unwrap();
-                                let err = format!("Invalid suffix {}. Did you mean u32, u64, i32, or i64?", ch);
-
-                                return Error(err);
-                            },
-
-                            // If eof or other just return the numeric token without a suffix
-                            _ => ()
+                            _ => match self.consume_numeric_suffix() {
+                                Ok(Some(t)) => suffix = Some(t),
+                                Ok(None) => (),
+                                Err(e) => return Error(e)
+                            }
                         };
                     },
                     _ => return Error(format!("Invalid number type {:?}", self.next_char())),
@@ -276,57 +238,135 @@ impl<'a> Lexer<'a> {
                             _  => number.push_str(&fractional)
                         }
 
-                        // Find float suffixes
-                        match self.next_char() {
-                            Some('f') => {
-                                let ch = self.consume_char().unwrap();
-
-                                match self.consume_32_64(ch) {
-                                    Ok(s)    => suffix.push_str(&s),
-                                    Err(err) => return Error(err)
-                                };
-                            },
-
-                            // Found some other suffix, ie 0x42o
-                            Some(c) if c.is_alphabetic() => {
-                                let ch = self.consume_char().unwrap();
-                                let err = format!("Invalid suffix {}. Did you mean f32, f64?", ch);
-
-                                return Error(err);
-                            },
-
-                            // No suffix found, can hit symbols or other
-                            _ => ()
-                        }
-                    },
-
-                    // Int suffixes:
-                    Some('u') |
-                    Some('i') => {
-                        let ch = self.consume_char().unwrap();
-
-                        match self.consume_32_64(ch) {
-                            Ok(s)    => suffix.push_str(&s),
-                            Err(err) => return Error(err)
+                        match self.consume_numeric_suffix() {
+                            Ok(Some(t)) => suffix = Some(t),
+                            Ok(None) => (),
+                            Err(e) => return Error(e)
                         };
                     },
-
-                    // Found some other suffix, ie 0x42o
-                    Some(c) if c.is_alphabetic() => {
-                        let ch = self.consume_char().unwrap();
-                        let err = format!("Invalid suffix {}. Did you mean u32, u64, i32, or i64?", ch);
-
-                        return Error(err);
-                    },
-
-                    // Presumably any other remaining char is valid, ie symbols {,[ etc
-                    _ => ()
+                    _ => match self.consume_numeric_suffix() {
+                        Ok(Some(t)) => suffix = Some(t),
+                        Ok(None) => (),
+                        Err(e) => return Error(e)
+                    }
                 };
             },
         }
 
-        Numeric(number, suffix.parse::<Types>().ok())
+        Numeric(number, suffix)
      }
+
+    fn consume_numeric_suffix(&mut self) -> Result<Option<Types>, String> {
+        let mut suffix = String::with_capacity(4);
+
+        match self.next_char() {
+            Some('u') |
+            Some('i') => {
+                suffix.push(self.consume_char().unwrap());
+                self.consume_numeric_suffix_end(&mut suffix, true)?;
+
+                Ok(suffix.parse::<Types>().ok())
+            },
+            Some('f') => {
+                suffix.push(self.consume_char().unwrap());
+                self.consume_numeric_suffix_end(&mut suffix, false)?;
+
+                Ok(suffix.parse::<Types>().ok())
+            },
+            Some(c) if c.is_alphabetic() => {
+                let ch = self.consume_char().unwrap();
+                let err = format!("Invalid suffix {}. Did you mean u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, or f128?", ch);
+
+                Err(err)
+            },
+            Some(_) => Ok(None),
+            None => Ok(None)
+        }
+    }
+
+    // Find a sequence of 8, 16 (if allowed), 32, 64, or 128
+    fn consume_numeric_suffix_end(&mut self, buffer: &mut String, allow_8_16: bool) -> Result<(), String> {
+        // buffer should contain the starting character, ie i, u, f
+        match self.next_char() {
+            Some('8') if allow_8_16 => {
+                buffer.push(self.consume_char().unwrap());
+
+                Ok(())
+            },
+            Some('1') => {
+                buffer.push(self.consume_char().unwrap());
+
+                match self.next_char() {
+                    Some('6') if allow_8_16 => {
+                        buffer.push(self.consume_char().unwrap());
+
+                        Ok(())
+                    },
+                    Some('2') => {
+                        buffer.push(self.consume_char().unwrap());
+
+                        match self.next_char() {
+                            Some('8') => {
+                                buffer.push(self.consume_char().unwrap());
+
+                                Ok(())
+                            },
+                            Some('\n') | // NL & CR have pesky visual effects.
+                            Some('\r') => Err(format!("Invalid suffix {}. Did you mean {0}8?", buffer)),
+                            Some(_) => Err(format!("Invalid suffix {}{}. Did you mean {0}8?", buffer, self.consume_char().unwrap())),
+                            None => Err(format!("Hit EOF when looking for suffix {}8", buffer)),
+                        }
+                    },
+                    Some('\n') | // NL & CR have pesky visual effects.
+                    Some('\r') => Err(format!("Invalid suffix {}. Did you mean {0}6 or {0}28?", buffer)),
+                    Some(_) => if allow_8_16 {
+                        Err(format!("Invalid suffix {}{}. Did you mean {0}6 or {0}28?", buffer, self.consume_char().unwrap()))
+                    } else {
+                        Err(format!("Invalid suffix {}{}. Did you mean {0}28?", buffer, self.consume_char().unwrap()))
+                    },
+                    None => if allow_8_16 {
+                        Err(format!("Hit EOF when looking for suffix {}16 or {0}128.", buffer))
+                    } else {
+                        Err(format!("Hit EOF when looking for suffix {}128", buffer))
+                    }
+                }
+            },
+            Some('3') => {
+                buffer.push(self.consume_char().unwrap());
+
+                match self.next_char() {
+                    Some('2')  => {
+                        buffer.push(self.consume_char().unwrap());
+
+                        Ok(())
+                    },
+                    Some('\n') | // NL & CR have pesky visual effects.
+                    Some('\r') => Err(format!("Invalid suffix {}. Did you mean {0}2?", buffer)),
+                    Some(_)    => Err(format!("Invalid suffix {}{}. Did you mean {0}2?", buffer, self.consume_char().unwrap())),
+                    None       => Err(format!("Hit EOF when looking for suffix {}32.", buffer))
+                }
+            },
+            Some('6') => {
+                buffer.push(self.consume_char().unwrap());
+
+                match self.next_char() {
+                    Some('4')  => {
+                        buffer.push(self.consume_char().unwrap());
+
+                        Ok(())
+                    },
+                    Some('\n') | // NL & CR have pesky visual effects.
+                    Some('\r') => Err(format!("Invalid suffix {}. Did you mean {0}4?", buffer)),
+                    Some(_)    => Err(format!("Invalid suffix {}{}. Did you mean {0}4?", buffer, self.consume_char().unwrap())),
+                    None       => Err(format!("Hit EOF when looking for suffix {}64.", buffer))
+                }
+            },
+            Some('\n') | // NL & CR have pesky visual effects.
+            Some('\r') => Err(format!("Invalid suffix {}. Did you mean {0}32, {0}64, or {0}128?", buffer)),
+            Some(_)    => Err(format!("Invalid suffix {}{}. Did you mean {0}32, {0}64, or {0}128?", buffer, self.consume_char().unwrap())),
+            None       => Err(format!("Hit EOF when looking for a suffix {0}32, {0}64, or {0}128.", buffer))
+        }
+    }
 
     fn consume_comment(&mut self) -> Tokens {
         let mut result = String::new();

--- a/src/lexical/lexer.rs
+++ b/src/lexical/lexer.rs
@@ -208,8 +208,7 @@ impl<'a> Lexer<'a> {
                                 Err(e) => return Error(e)
                             }
                         };
-                    },
-                    _ => return Error(format!("Invalid number type {:?}", self.next_char())),
+                    }
                 }
             },
             _ => {

--- a/src/lexical/types.rs
+++ b/src/lexical/types.rs
@@ -9,12 +9,15 @@ pub enum Types {
     Int16Bit,
     Int32Bit,
     Int64Bit,
+    Int128Bit,
     UInt8Bit,
     UInt16Bit,
     UInt32Bit,
     UInt64Bit,
+    UInt128Bit,
     Float32Bit,
     Float64Bit,
+    Float128Bit,
     NoneType
 }
 
@@ -30,12 +33,15 @@ impl FromStr for Types {
             "i16"  => Ok(Types::Int16Bit),
             "i32"  => Ok(Types::Int32Bit),
             "i64"  => Ok(Types::Int64Bit),
+            "i128" => Ok(Types::Int128Bit),
             "u8"   => Ok(Types::UInt8Bit),
             "u16"  => Ok(Types::UInt16Bit),
             "u32"  => Ok(Types::UInt32Bit),
             "u64"  => Ok(Types::UInt64Bit),
+            "u128" => Ok(Types::UInt128Bit),
             "f32"  => Ok(Types::Float32Bit),
             "f64"  => Ok(Types::Float64Bit),
+            "f128" => Ok(Types::Float128Bit),
             "None" => Ok(Types::NoneType),
             _      => Err(())
         }

--- a/src/semantic/type_checker.rs
+++ b/src/semantic/type_checker.rs
@@ -112,7 +112,11 @@ impl ASTAnalyzer<Option<String>> for TypeChecker {
                 let lhs_type = self.analyze(lhs_expr_wrapper).unwrap();
                 let rhs_type = self.analyze(rhs_expr_wrapper).unwrap();
 
-                TypeChecker::cmp_lhs_rhs(lhs_type, rhs_type)
+                match TypeChecker::cmp_lhs_rhs(lhs_type, rhs_type) {
+                    Some(_) if op.returns_bool() => Some("bool".into()),
+                    Some(t) => Some(t),
+                    None => None,
+                }
             },
             Literal(ref literal) => Some(literal.to_string()), // Done?
             Return(ref mut opt_ret_type) => match *opt_ret_type { // Done?
@@ -120,7 +124,7 @@ impl ASTAnalyzer<Option<String>> for TypeChecker {
                 None => Some("None".into()) // None type?
             },
             UnaryOp(ref op, ref mut expr_wrapper) => self.analyze(expr_wrapper),
-            Var(ref name) => unimplemented!(), // FIXME: Lookup VarDecl type
+            Var(ref name) => return Some("i32".into()), // FIXME: Lookup VarDecl type
             VarDecl(ref const_, ref name, ref mut opt_type, ref mut expr_wrapper) => {
                 let rhs_type = self.analyze(expr_wrapper).unwrap();
 

--- a/src/syntax/op.rs
+++ b/src/syntax/op.rs
@@ -50,6 +50,17 @@ impl InfixOp {
             InfixOp::Pow => 3 // Not sure about this one
         }
     }
+
+    pub fn returns_bool(&self) -> bool {
+        match *self {
+            InfixOp::Lt  => true,
+            InfixOp::Lte => true,
+            InfixOp::Gt  => true,
+            InfixOp::Gte => true,
+            InfixOp::Equ => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/tests/test_lexer.rs
+++ b/tests/test_lexer.rs
@@ -4,7 +4,7 @@ use limonite::lexical::keywords::Keywords::{Def, Function, If, Is, Return, Var};
 use limonite::lexical::symbols::Symbols::{Comma, Equals, ParenClose, ParenOpen, PlusEquals, RightThinArrow};
 use limonite::lexical::tokens::Tokens;
 use limonite::lexical::tokens::Tokens::{BoolLiteral, CharLiteral, Comment, EOF, Error, Identifier, Indent, Keyword, Numeric, Symbol, StrLiteral};
-use limonite::lexical::types::Types::{Float32Bit, Float64Bit, Int32Bit, Int64Bit, UInt32Bit, UInt64Bit};
+use limonite::lexical::types::Types::{Float32Bit, Float64Bit, Int32Bit, Int64Bit, UInt8Bit, UInt32Bit, UInt64Bit, Float128Bit, UInt128Bit};
 use limonite::lexical::lexer::{Lexer};
 
 fn cmp_tokens(mut lexer: Lexer, vec: Vec<Tokens>) {
@@ -72,6 +72,7 @@ if True,
 
 #[test]
 fn test_valid_numerics() {
+    // REVIEW: is f32/64 a valid suffix without decimal place? Thinking yes. Check rust
     let input_string = "\
 0xF3a
 0xfffi32
@@ -94,7 +95,13 @@ fn test_valid_numerics() {
 0xFFFF_FFFF
 0b0101_0101
 400_000
-400_000.000_000";
+400_000.000_000
+0f32
+0001
+0000_0000
+0000_0001u8
+1.0f128
+117u128";
 
     let lexer = Lexer::new(&input_string);
     let desired_output = vec![Numeric("0xF3a".to_string(), None), Indent(0),
@@ -118,7 +125,13 @@ fn test_valid_numerics() {
                               Numeric("0xFFFF_FFFF".to_string(), None), Indent(0),
                               Numeric("0b0101_0101".to_string(), None), Indent(0),
                               Numeric("400_000".to_string(), None), Indent(0),
-                              Numeric("400_000.000_000".to_string(), None), EOF];
+                              Numeric("400_000.000_000".to_string(), None), Indent(0),
+                              Numeric("0".to_string(), Some(Float32Bit)), Indent(0),
+                              Numeric("0001".to_string(), None), Indent(0),
+                              Numeric("0000_0000".to_string(), None), Indent(0),
+                              Numeric("0000_0001".to_string(), Some(UInt8Bit)), Indent(0),
+                              Numeric("1.0".to_string(), Some(Float128Bit)), Indent(0),
+                              Numeric("117".to_string(), Some(UInt128Bit)), EOF];
 
     cmp_tokens(lexer, desired_output);
 }
@@ -133,39 +146,41 @@ fn test_invalid_numerics() {
 0xfi31
 0xfi6
 0xfi63
-0xfu8
 0b
 0ba
 0b1a
 0b1f
-42f32
 42i3
 42i31
 42.
 42.0f
 42.0f3
-42.0f31";
+42.0f31
+42.0f8
+42.0f16";
 
     let lexer = Lexer::new(&input_string);
     let desired_output = vec![Error("No hexadecimal value was found.".to_string()), Indent(0),
                               Error("No hexadecimal value was found.".to_string()), Identifier("z".to_string()), Indent(0),
-                              Error("Invalid suffix z. Did you mean u32, u64, i32, or i64?".to_string()), Indent(0),
+                              Error("Invalid suffix z. Did you mean u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, or f128?".to_string()), Indent(0),
                               Error("Invalid suffix i3. Did you mean i32?".to_string()), Indent(0),
                               Error("Invalid suffix i31. Did you mean i32?".to_string()), Indent(0),
                               Error("Invalid suffix i6. Did you mean i64?".to_string()), Indent(0),
                               Error("Invalid suffix i63. Did you mean i64?".to_string()), Indent(0),
-                              Error("Invalid suffix u8. Did you mean u32 or u64?".to_string()), Indent(0),
+                              // Error("Invalid suffix u8. Did you mean u32 or u64?".to_string()), Indent(0),
                               Error("No binary value was found.".to_string()), Indent(0),
                               Error("No binary value was found.".to_string()), Identifier("a".to_string()), Indent(0),
-                              Error("Invalid suffix a. Did you mean u32, u64, i32, or i64?".to_string()), Indent(0),
-                              Error("Invalid suffix f. Did you mean u32, u64, i32, or i64?".to_string()), Indent(0),
-                              Error("Invalid suffix f. Did you mean u32, u64, i32, or i64?".to_string()), Numeric("32".to_string(), None), Indent(0),
+                              Error("Invalid suffix a. Did you mean u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64, or f128?".to_string()), Indent(0),
+                              Error("Invalid suffix f. Did you mean f32, f64, or f128?".to_string()), Indent(0),
+                              // Error("Invalid suffix f. Did you mean u32, u64, i32, or i64?".to_string()), Numeric("32".to_string(), None), Indent(0),
                               Error("Invalid suffix i3. Did you mean i32?".to_string()), Indent(0),
                               Error("Invalid suffix i31. Did you mean i32?".to_string()), Indent(0),
                               Error("No numbers found after the decimal point.".to_string()), Indent(0),
-                              Error("Invalid suffix f. Did you mean f32 or f64?".to_string()), Indent(0),
+                              Error("Invalid suffix f. Did you mean f32, f64, or f128?".to_string()), Indent(0),
                               Error("Invalid suffix f3. Did you mean f32?".to_string()), Indent(0),
-                              Error("Invalid suffix f31. Did you mean f32?".to_string()), EOF];
+                              Error("Invalid suffix f31. Did you mean f32?".to_string()), Indent(0),
+                              Error("Invalid suffix f8. Did you mean f32, f64, or f128?".to_string()), Indent(0),
+                              Error("Invalid suffix f16. Did you mean f128?".to_string()), EOF];
 
     cmp_tokens(lexer, desired_output);
 }

--- a/tests/test_llvm_codegen.rs
+++ b/tests/test_llvm_codegen.rs
@@ -7,63 +7,6 @@ use limonite::syntax::literals::Literals;
 
 use std::mem::transmute;
 
-macro_rules! block {
-    ($($args:tt)*) => {
-        ExprWrapper::default(Expr::Block(vec![$($args)*]))
-    }
-}
-
-macro_rules! var {
-    ($arg:expr) => {
-        ExprWrapper::default(Expr::Var($arg.into()))
-    }
-}
-
-macro_rules! ret {
-    () => {
-        ExprWrapper::default(Expr::Return(None))
-    };
-    ($arg:expr) => {
-        ExprWrapper::default(Expr::Return(Some($arg)))
-    };
-}
-
-macro_rules! u8 {
-    ($arg:tt) => {
-        ExprWrapper::default(Expr::Literal(Literals::U8Num($arg)))
-    }
-}
-
-macro_rules! string {
-    ($arg:tt) => {
-        ExprWrapper::default(Expr::Literal(Literals::UTF8String($arg.into())))
-    }
-}
-
-macro_rules! op {
-    ($left_arg:expr, + $right_arg:expr) => {
-        ExprWrapper::default(Expr::InfixOp(InfixOp::Add, $left_arg, $right_arg))
-    };
-    ($left_arg:expr, < $right_arg:expr) => {
-        ExprWrapper::default(Expr::InfixOp(InfixOp::Lt, $left_arg, $right_arg))
-    };
-    ($left_arg:expr, > $right_arg:expr) => {
-        ExprWrapper::default(Expr::InfixOp(InfixOp::Gt, $left_arg, $right_arg))
-    };
-}
-
-macro_rules! assign {
-    ($left_arg:expr, = $right_arg:expr) => {
-        ExprWrapper::default(Expr::Assign($left_arg, $right_arg))
-    };
-    ($left_arg:expr, += $right_arg:expr) => {
-        ExprWrapper::default(Expr::Assign($left_arg, ExprWrapper::default(Expr::InfixOp(InfixOp::Add, $left_arg, $right_arg))))
-    };
-    ($left_arg:expr, -= $right_arg:expr) => {
-        ExprWrapper::default(Expr::Assign($left_arg, ExprWrapper::default(Expr::InfixOp(InfixOp::Sub, $left_arg, $right_arg))))
-    };
-}
-
 #[test]
 fn test_sum_function() {
     // Creates a limonite function that looks like:

--- a/tests/test_parser.rs
+++ b/tests/test_parser.rs
@@ -379,6 +379,27 @@ fn test_assign() {
         ))
     ];
     expect_test(tokens, desired_ast);
+
+    let tokens = vec![
+        Identifier("b".to_string()),
+        Symbol(Symbols::PlusEquals),
+        Numeric("123".to_string(), Some(Types::UInt32Bit)),
+    ];
+    let desired_ast = vec![
+        assign!(var!("b"), += u32!(123))
+    ];
+    expect_test(tokens, desired_ast);
+
+    let tokens = vec![
+        Identifier("b".to_string()),
+        Symbol(Symbols::MinusEquals),
+        Numeric("123".to_string(), Some(Types::UInt32Bit)),
+    ];
+    let desired_ast = vec![
+        assign!(var!("b"), -= u32!(123))
+
+    ];
+    expect_test(tokens, desired_ast);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,9 @@
 extern crate limonite;
 
-pub mod test_lexer;
+#[macro_use]
+mod utils;
+mod test_lexer;
 #[cfg(feature="llvm-backend")]
-pub mod test_llvm_codegen;
-pub mod test_parser;
-pub mod test_type_checker;
+mod test_llvm_codegen;
+mod test_parser;
+mod test_type_checker;

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -7,7 +7,7 @@ macro_rules! block {
 macro_rules! var {
     ($arg:expr) => {
         ExprWrapper::default(Expr::Var($arg.into()))
-    }
+    };
 }
 
 macro_rules! ret {
@@ -25,6 +25,12 @@ macro_rules! u8 {
     }
 }
 
+macro_rules! u32 {
+    ($arg:tt) => {
+        ExprWrapper::default(Expr::Literal(Literals::U32Num($arg)))
+    }
+}
+
 macro_rules! string {
     ($arg:tt) => {
         ExprWrapper::default(Expr::Literal(Literals::UTF8String($arg.into())))
@@ -34,6 +40,15 @@ macro_rules! string {
 macro_rules! op {
     ($left_arg:expr, + $right_arg:expr) => {
         ExprWrapper::default(Expr::InfixOp(InfixOp::Add, $left_arg, $right_arg))
+    };
+    ($left_arg:expr, - $right_arg:expr) => {
+        ExprWrapper::default(Expr::InfixOp(InfixOp::Sub, $left_arg, $right_arg))
+    };
+    ($left_arg:expr, * $right_arg:expr) => {
+        ExprWrapper::default(Expr::InfixOp(InfixOp::Mul, $left_arg, $right_arg))
+    };
+    ($left_arg:expr, / $right_arg:expr) => {
+        ExprWrapper::default(Expr::InfixOp(InfixOp::Div, $left_arg, $right_arg))
     };
     ($left_arg:expr, < $right_arg:expr) => {
         ExprWrapper::default(Expr::InfixOp(InfixOp::Lt, $left_arg, $right_arg))
@@ -54,15 +69,15 @@ macro_rules! assign {
         ExprWrapper::default(Expr::Assign($left_arg, $right_arg))
     };
     ($left_arg:expr, += $right_arg:expr) => {
-        ExprWrapper::default(Expr::Assign($left_arg, ExprWrapper::default(Expr::InfixOp(InfixOp::Add, $left_arg, $right_arg))))
+        ExprWrapper::default(Expr::Assign($left_arg, op!($left_arg, + $right_arg)))
     };
     ($left_arg:expr, -= $right_arg:expr) => {
-        ExprWrapper::default(Expr::Assign($left_arg, ExprWrapper::default(Expr::InfixOp(InfixOp::Sub, $left_arg, $right_arg))))
+        ExprWrapper::default(Expr::Assign($left_arg, op!($left_arg, - $right_arg)))
     };
     ($left_arg:expr, *= $right_arg:expr) => {
-        ExprWrapper::default(Expr::Assign($left_arg, ExprWrapper::default(Expr::InfixOp(InfixOp::Mul, $left_arg, $right_arg))))
+        ExprWrapper::default(Expr::Assign($left_arg, op!($left_arg, * $right_arg)))
     };
     ($left_arg:expr, /= $right_arg:expr) => {
-        ExprWrapper::default(Expr::Assign($left_arg, ExprWrapper::default(Expr::InfixOp(InfixOp::Div, $left_arg, $right_arg))))
+        ExprWrapper::default(Expr::Assign($left_arg, op!($left_arg, / $right_arg)))
     };
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,0 +1,68 @@
+macro_rules! block {
+    ($($args:tt)*) => {
+        ExprWrapper::default(Expr::Block(vec![$($args)*]))
+    }
+}
+
+macro_rules! var {
+    ($arg:expr) => {
+        ExprWrapper::default(Expr::Var($arg.into()))
+    }
+}
+
+macro_rules! ret {
+    () => {
+        ExprWrapper::default(Expr::Return(None))
+    };
+    ($arg:expr) => {
+        ExprWrapper::default(Expr::Return(Some($arg)))
+    };
+}
+
+macro_rules! u8 {
+    ($arg:tt) => {
+        ExprWrapper::default(Expr::Literal(Literals::U8Num($arg)))
+    }
+}
+
+macro_rules! string {
+    ($arg:tt) => {
+        ExprWrapper::default(Expr::Literal(Literals::UTF8String($arg.into())))
+    }
+}
+
+macro_rules! op {
+    ($left_arg:expr, + $right_arg:expr) => {
+        ExprWrapper::default(Expr::InfixOp(InfixOp::Add, $left_arg, $right_arg))
+    };
+    ($left_arg:expr, < $right_arg:expr) => {
+        ExprWrapper::default(Expr::InfixOp(InfixOp::Lt, $left_arg, $right_arg))
+    };
+    ($left_arg:expr, <= $right_arg:expr) => {
+        ExprWrapper::default(Expr::InfixOp(InfixOp::Lte, $left_arg, $right_arg))
+    };
+    ($left_arg:expr, > $right_arg:expr) => {
+        ExprWrapper::default(Expr::InfixOp(InfixOp::Gt, $left_arg, $right_arg))
+    };
+    ($left_arg:expr, >= $right_arg:expr) => {
+        ExprWrapper::default(Expr::InfixOp(InfixOp::Gte, $left_arg, $right_arg))
+    };
+}
+
+macro_rules! assign {
+    ($left_arg:expr, = $right_arg:expr) => {
+        ExprWrapper::default(Expr::Assign($left_arg, $right_arg))
+    };
+    ($left_arg:expr, += $right_arg:expr) => {
+        ExprWrapper::default(Expr::Assign($left_arg, ExprWrapper::default(Expr::InfixOp(InfixOp::Add, $left_arg, $right_arg))))
+    };
+    ($left_arg:expr, -= $right_arg:expr) => {
+        ExprWrapper::default(Expr::Assign($left_arg, ExprWrapper::default(Expr::InfixOp(InfixOp::Sub, $left_arg, $right_arg))))
+    };
+    ($left_arg:expr, *= $right_arg:expr) => {
+        ExprWrapper::default(Expr::Assign($left_arg, ExprWrapper::default(Expr::InfixOp(InfixOp::Mul, $left_arg, $right_arg))))
+    };
+    ($left_arg:expr, /= $right_arg:expr) => {
+        ExprWrapper::default(Expr::Assign($left_arg, ExprWrapper::default(Expr::InfixOp(InfixOp::Div, $left_arg, $right_arg))))
+    };
+}


### PR DESCRIPTION
* While loop support in Parser
* Updated README to show how to print a while loop
* More builder and type methods
* Lexer & Parser support for u128, i128, f128, comparators
* Fixed lexer bug where numbers starting with 0 didn't parse correctly

This is the final PR where LLVM wrapper changes are being made. From here on out the LLVM wrapper will be worked on in [yallow](https://github.com/TheDan64/yallow) as per #50 
